### PR TITLE
Feature suggestion - ability to redirect TTS audio output into earpiece or speaker

### DIFF
--- a/src/ios/CDVTTS.h
+++ b/src/ios/CDVTTS.h
@@ -17,6 +17,8 @@
     NSString* callbackId;
 }
 
+- (void)setSpeaker:(CDVInvokedUrlCommand*)command;
+- (void)setEarpiece:(CDVInvokedUrlCommand*)command;
 - (void)speak:(CDVInvokedUrlCommand*)command;
 - (void)stop:(CDVInvokedUrlCommand*)command;
 - (void)checkLanguage:(CDVInvokedUrlCommand*)command;

--- a/src/ios/CDVTTS.m
+++ b/src/ios/CDVTTS.m
@@ -33,7 +33,7 @@
     }
     
     [[AVAudioSession sharedInstance] setActive:NO withOptions:0 error:nil];
-    [[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryPlayAndRecord error: nil];
+    [[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryAmbient error: nil];
     [[AVAudioSession sharedInstance] setActive:YES withOptions: 0 error:nil];
 }
 
@@ -59,7 +59,7 @@
 
     callbackId = command.callbackId;
     [[AVAudioSession sharedInstance] setActive:NO withOptions:0 error:nil];
-    [[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryPlayAndRecord error:nil];
+    [[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryAmbient error:nil];
     
     NSDictionary* options = [command.arguments objectAtIndex:0];
 

--- a/src/ios/CDVTTS.m
+++ b/src/ios/CDVTTS.m
@@ -33,10 +33,24 @@
     }
     
     [[AVAudioSession sharedInstance] setActive:NO withOptions:0 error:nil];
-    [[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryAmbient
-      withOptions: 0 error: nil];
+    [[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryPlayAndRecord error: nil];
     [[AVAudioSession sharedInstance] setActive:YES withOptions: 0 error:nil];
 }
+
+- (void)setSpeaker:(CDVInvokedUrlCommand *)command {
+    [synthesizer pauseSpeakingAtBoundary:AVSpeechBoundaryImmediate];
+    NSLog(@"TTS: setting output into speaker");
+    [[AVAudioSession sharedInstance] overrideOutputAudioPort:AVAudioSessionPortOverrideSpeaker error:nil];
+    [synthesizer continueSpeaking];
+}
+
+- (void)setEarpiece:(CDVInvokedUrlCommand *)command {
+    [synthesizer pauseSpeakingAtBoundary:AVSpeechBoundaryImmediate];
+    NSLog(@"TTS: setting output into earpiece");
+    [[AVAudioSession sharedInstance] overrideOutputAudioPort:AVAudioSessionPortOverrideNone error:nil];
+    [synthesizer continueSpeaking];
+}
+
 
 - (void)speak:(CDVInvokedUrlCommand*)command {
     if (callbackId) {
@@ -45,9 +59,8 @@
 
     callbackId = command.callbackId;
     [[AVAudioSession sharedInstance] setActive:NO withOptions:0 error:nil];
-    [[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryPlayback
-        withOptions:AVAudioSessionCategoryOptionDuckOthers error:nil];
-
+    [[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryPlayAndRecord error:nil];
+    
     NSDictionary* options = [command.arguments objectAtIndex:0];
 
     NSString* text = [options objectForKey:@"text"];
@@ -58,6 +71,14 @@
     double rate = [[options objectForKey:@"rate"] doubleValue];
     double pitch = [[options objectForKey:@"pitch"] doubleValue];
     double volume = [[options objectForKey:@"volume"] doubleValue];
+    bool earpiece = [[options objectForKey:@"earpiece"] boolValue];
+
+    if (earpiece == true){
+        NSLog(@"TTS: setting output into earpiece");
+        [[AVAudioSession sharedInstance] overrideOutputAudioPort:AVAudioSessionPortOverrideNone error:nil];
+    } else{
+        [[AVAudioSession sharedInstance] overrideOutputAudioPort:AVAudioSessionPortOverrideSpeaker error:nil];
+    }
 
     if (!rate) {
         rate = AVSpeechUtteranceDefaultSpeechRate;

--- a/src/ios/CDVTTS.m
+++ b/src/ios/CDVTTS.m
@@ -33,7 +33,7 @@
     }
     
     [[AVAudioSession sharedInstance] setActive:NO withOptions:0 error:nil];
-    [[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryAmbient error: nil];
+    [[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryPlayAndRecord error: nil];
     [[AVAudioSession sharedInstance] setActive:YES withOptions: 0 error:nil];
 }
 
@@ -59,7 +59,7 @@
 
     callbackId = command.callbackId;
     [[AVAudioSession sharedInstance] setActive:NO withOptions:0 error:nil];
-    [[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryAmbient error:nil];
+    [[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryPlayAndRecord error:nil];
     
     NSDictionary* options = [command.arguments objectAtIndex:0];
 

--- a/www/tts.js
+++ b/www/tts.js
@@ -47,3 +47,15 @@ exports.openInstallTts = function () {
     cordova.exec(resolve, reject, "TTS", "openInstallTts", []);
   });
 };
+
+exports.setSpeaker = function(){
+  return new Promise(function (resolve, reject) {
+    cordova.exec(resolve, reject, "TTS", "setSpeaker", []);
+  });
+};
+
+exports.setEarpiece = function(){
+  return new Promise(function (resolve, reject) {
+    cordova.exec(resolve, reject, "TTS", "setEarpiece", []);
+  });
+};


### PR DESCRIPTION
speak() method: added boolean option "earpiece" to start reading directly into phone's earpiece
setSpeaker() method: switch audio routing into speaker even when reading is already started
setEarpiece() method: switch audio route into earpiece

tested only on IOS 15.3, android methods implemented but not tested yet, but should be working

source code used from cordova-plugin-audiotoggle plugin